### PR TITLE
Cannot update ssl certificate when update listener

### DIFF
--- a/neutron_lbaas_dashboard/api/rest/lbaasv2.py
+++ b/neutron_lbaas_dashboard/api/rest/lbaasv2.py
@@ -100,7 +100,6 @@ def create_listener(request, **kwargs):
         listenerSpec['description'] = data['listener']['description']
     if data.get('certificates'):
         listenerSpec['default_tls_container_ref'] = data['certificates'][0]
-        listenerSpec['sni_container_refs'] = data['certificates']
 
     listener = neutronclient(request).create_listener(
         {'listener': listenerSpec}).get('listener')
@@ -269,6 +268,8 @@ def update_listener(request, **kwargs):
         listener_spec['name'] = data['listener']['name']
     if data['listener'].get('description'):
         listener_spec['description'] = data['listener']['description']
+    if data.get('certificates'):
+        listener_spec['default_tls_container_ref'] = data['certificates'][0]
 
     listener = neutronclient(request).update_listener(
         listener_id, {'listener': listener_spec}).get('listener')


### PR DESCRIPTION
Update listener success, but only the name and description of the
listener has been updated. Certificate remains same as old one.

Change-Id: I35aa3ca8d77f5cd58d8bd945fadc1061ecf05112
Closes-Bug: #1753656
(cherry picked from commit d87d0e3bd275d88e9beb5c4e9c2e1750893268d4)
(cherry picked from commit be052c5212c8da384f2a15c25e153d9cf638815a)